### PR TITLE
feat(gui): select models from list and remove timeout explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Launch the graphical interface with:
 python gui.py
 ```
 
+The GUI displays available models for selection and no longer includes the timeout explanation field.
+
 ## Development
 
 See [AGENTS.md](AGENTS.md) for contribution guidelines.


### PR DESCRIPTION
## Summary
- allow choosing models from a clickable list of available Groq models
- drop the timeout explanation field from the GUI
- document the new GUI behavior

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8e8641bc4832eba28a5dd0abbfc7b