### PR TITLE
Include existing solution code in model prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ python main.py --task "write fibonacci" --tests "assert solution.fib(5) == 5"
 Run `python main.py --help` to see all available options.
 
 If a file named `solution.py` already exists in the working directory, the agent
-uses it as the starting point instead of generating a fresh implementation.
+uses it as the starting point instead of generating a fresh implementation. The
+current contents of `solution.py` are included in prompts to the models so they
+can build on or repair the existing solution.
 
 ## GUI
 


### PR DESCRIPTION
## Summary
- Include existing `solution.py` content in model prompts via updated `build_user_prompt` and `build_tests_prompt`
- Load existing solution before prompt construction so models can build on it
- Document that existing solution code is now passed to models

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa17c7ce30832eb32335126f8b4d6b