### PR TITLE
Limit GUI/game tasks to run-only execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ current contents of `solution.py` are included in prompts and the models are
 explicitly instructed to update or extend this code, rather than replacing it
 with an unrelated program.
 
+### GUI / Game Tasks
+
+When your task describes a GUI application or a game, Angler Fish skips unit
+test generation and simply runs the produced module to ensure it executes
+without raising an error. The agent determines whether a task is GUI or game
+related by asking each selected model and treating it as such only if a strict
+majority votes "yes".
+
 ## GUI
 
 Launch the graphical interface with:


### PR DESCRIPTION
## Summary
- Detect GUI/game tasks using model majority vote
- Skip unit tests for GUI or game tasks and run the module to verify it executes
- Document GUI/game workflow in README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa2463ee20832ea6954b7816bcfebd